### PR TITLE
Improve acquisition of commit message header

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,13 +41,13 @@ runs:
         # Check if there is a commit message
         if [ -n "${{ github.event.head_commit.message }}" ]; then
           # Extract the first line of the commit message
-          description=$(echo "${{ github.event.head_commit.message }}" | sed -n '1p')
+          description=$(git log -1 --pretty=%B | head -n 1)
         else
-          # Default description if no commit message is available (Or manual trigger)
-          description="Artefacts CI check"
+          # Default description if no commit message is available
+          description="Artefacts Github Action"
         fi
         # Output the description to the GitHub environment
-        echo "DESCRIPTION=${description//[$'\t\r\n']/ }" >> $GITHUB_ENV
+        echo "DESCRIPTION=${description}" >> $GITHUB_ENV
       shell: bash
 
     - name: Run remote job

--- a/action.yaml
+++ b/action.yaml
@@ -38,11 +38,9 @@ runs:
     - name: Set commit description
       id: set-description
       run: |
-        # Check if there is a commit message
-        if [ -n "${{ github.event.head_commit.message }}" ]; then
-          # Extract the first line of the commit message
-          description=$(git log -1 --pretty=%B | head -n 1)
-        else
+        # Check if there is a commit message using git log
+        description=$(git log -1 --pretty=%B 2>/dev/null | head -n 1)
+        if [ -z "$description" ]; then
           # Default description if no commit message is available
           description="Artefacts Github Action"
         fi


### PR DESCRIPTION
This should make it more likely that we do report the commit message for CI runs, as opposed to "CI check" that we currently have.
The github variable are quite different depending on the type of trigger, so this makes it more generic.

Backup text, which may not be needed anymore (I think experience will tell) has also be rephrased to be more specific.
This should address some aspects of the discussion in https://github.com/art-e-fact/artefacts-client/issues/94